### PR TITLE
fix nested anchor issue

### DIFF
--- a/components/agenda/session/index.vue
+++ b/components/agenda/session/index.vue
@@ -8,10 +8,9 @@ defineProps({
 </script>
 
 <template>
-  <NuxtLink
-    :href="href"
-    tabindex="0"
-  >
+  <div class="relative">
+    <NuxtLink :to="href" class="absolute inset-0 z-0" tabindex="0">
+    </NuxtLink>
     <slot></slot>
-  </NuxtLink>
+  </div>
 </template>

--- a/components/agenda/session/speaker/index.vue
+++ b/components/agenda/session/speaker/index.vue
@@ -5,22 +5,10 @@ const props = defineProps({
     type: String,
   },
 })
-
-const router = useRouter()
-
-function navigateToHref() {
-  router.push(props.href)
-}
 </script>
 
 <template>
-  <span
-    :data-href="href"
-    tabindex="0"
-    role="link"
-    @click.prevent="navigateToHref"
-    @keyup.enter.prevent="navigateToHref"
-  >
+  <a :href="href" tabindex="0">
     <slot></slot>
-  </span>
+  </a>
 </template>


### PR DESCRIPTION
@n-d-r-d-g This error happens because indeed, <a> tags cannot be nested inside each other.
 
The solution is to make them siblings or overlay them on different layers. 

It's quite a common pattern you'll find in tailwind based cards, where you want allow the user to click the whole card, but also elements inside the card.

I've suggested a fix to your pr